### PR TITLE
Add -d flag to gitWorkflow untracked files cleanup

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -27,7 +27,7 @@ const cleanUntrackedFiles = async execGit => {
       'This is probably due to a bug in git =< 2.13.0 where `git stash --keep-index` resurrects deleted files.'
     )
     debug('Deleting the files using `git clean`...')
-    await execGit(['clean', '--force', ...untrackedFiles.split('\n')])
+    await execGit(['clean', '-df', ...untrackedFiles.split('\n')])
   }
 }
 


### PR DESCRIPTION
This PR adds -d flag to gitWorkflow untracked files cleanup.